### PR TITLE
Fix - CORS content type headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "pact-stub-server"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "expectest 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/release-ios.sh
+++ b/release-ios.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+cargo clean
+cargo build --release --target x86_64-apple-ios
+gzip -c target/x86_64-apple-ios/release/pact-stub-server > target/x86_64-apple-ios/release/pact-stub-server-ios-x86_64-$1.gz

--- a/release-osx.sh
+++ b/release-osx.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -xe
 cargo clean
 cargo build --release
-cargo build --release --target x86_64-apple-ios
 gzip -c target/release/pact-stub-server > target/release/pact-stub-server-osx-x86_64-$1.gz
-gzip -c target/x86_64-apple-ios/release/pact-stub-server > target/x86_64-apple-ios/release/pact-stub-server-ios-x86_64-$1.gz

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,7 @@ impl ServerHandler {
               if self.auto_cors && request.method.to_uppercase() == "OPTIONS" {
                 Ok(Response {
                   headers: Some(hashmap!{
-                    s!("Access-Control-Allow-Headers") => s!("authorization"),
+                    s!("Access-Control-Allow-Headers") => s!("authorization,Content-Type"),
                     s!("Access-Control-Allow-Methods") => s!("GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH"),
                     s!("Access-Control-Allow-Origin") => s!("*")
                   }),


### PR DESCRIPTION
The 'Access-Control-Allow-Headers' on the CORS option, didn't allow for the 'Content-Type' to be set. This meant that a POST request body was restricted to form data or plain text, not json.

Additionally, the iOS parts of the `release-osx.sh` was separated.