### PR TITLE
fix: move #[global_allocator] from lib to binary crate

### DIFF
--- a/src/bin/pact-stub-server.rs
+++ b/src/bin/pact-stub-server.rs
@@ -1,6 +1,10 @@
 use std::env;
 use std::process::ExitCode;
+use mimalloc::MiMalloc;
 use pact_stub_server::handle_command_args;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), ExitCode> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ use std::sync::mpsc::channel;
 
 use clap::{Command, Arg, ArgMatches, ArgAction, command, crate_version};
 use clap::error::ErrorKind;
-use mimalloc::MiMalloc;
 use pact_models::prelude::*;
 use pact_models::prelude::v4::*;
 use regex::Regex;
@@ -206,9 +205,6 @@ fn get_watch_paths(sources: &[PactSource]) -> Vec<PathBuf> {
 mod pact_support;
 mod server;
 mod loading;
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 
 pub fn print_version() {


### PR DESCRIPTION
When pact-stub-server is used as a library (e.g. embedded in pact-cli), the `#[global_allocator]` declaration in `lib.rs` imposed mimalloc as the allocator for the entire host binary. This caused mimalloc to `abort()` with no Rust panic message when OpenTelemetry was active in the host process, because OTEL's internal heap activity violated a mimalloc invariant.

Moving the declaration to bin/pact-stub-server.rs means:
- The standalone pact-stub-server binary still uses mimalloc (no change in performance characteristics)
- Library consumers get the system/default allocator and are not affected